### PR TITLE
Forward CustomElements and HTMLImports loader flags

### DIFF
--- a/build/if-poly.js
+++ b/build/if-poly.js
@@ -11,21 +11,45 @@ window.logFlags = window.logFlags || {};
     o = o.split('=');
     o[0] && (flags[o[0]] = o[1] || true);
   });
+  var entryPoint = document.currentScript || document.querySelector('script[src*="platform.js"]');
+  if (entryPoint) {
+    var a = entryPoint.attributes;
+    for (var i = 0, n; i < a.length; i++) {
+      n = a[i];
+      if (n.name !== 'src') {
+        flags[n.name] = n.value || true;
+      }
+    }
+  }
+  if (flags.log) {
+    flags.log.split(',').forEach(function(f) {
+      window.logFlags[f] = true;
+    });
+  }
   // If any of these flags match 'native', then force native ShadowDOM; any
   // other truthy value, or failure to detect native
-  // ShadowDOM, results in polyfill 
+  // ShadowDOM, results in polyfill
   flags.shadow = (flags.shadow || flags.shadowdom || flags.polyfill);
   if (flags.shadow === 'native') {
     flags.shadow = false;
   } else {
-    flags.shadow = flags.shadow || !HTMLElement.prototype.createShadowRoot
-        && 'polyfill';
+    flags.shadow = flags.shadow || !HTMLElement.prototype.createShadowRoot;
   }
 
+  // CustomElements polyfill flag
+  if (flags.register) {
+    window.CustomElements = window.CustomElements || {flags: {}};
+    window.CustomElements.flags.register = flags.register;
+  }
 
+  if (flags.imports) {
+    window.HTMLImports = window.HTMLImports || {flags: {}};
+    window.HTMLImports.flags.imports = flags.imports;
+  }
 
   // export
   scope.flags = flags;
 })(Platform);
+
 // select ShadowDOM impl
-if (Platform.flags.shadow === 'polyfill') {
+if (Platform.flags.shadow) {

--- a/platform.js
+++ b/platform.js
@@ -21,8 +21,7 @@ function processFlags(flags) {
     if (flags.shadow === 'native') {
       flags.shadow = false;
     } else {
-      flags.shadow = flags.shadow || !HTMLElement.prototype.createShadowRoot
-          && 'polyfill';
+      flags.shadow = flags.shadow || !HTMLElement.prototype.createShadowRoot;
     }
 
     var ShadowDOMNative = [


### PR DESCRIPTION
Add script attribute loader option to build

Remove 'shadow=polyfill' special case

Debug loader never checked that shadowdom === 'polyfill', but build did.
Removing this difference in semantics makes the 'polyfill' case unnecessary.
