### PR TITLE
Loader Refactor - Minimize network requests

### DIFF
--- a/test/html/styling/recursive-style-import.html
+++ b/test/html/styling/recursive-style-import.html
@@ -58,6 +58,7 @@ license that can be found in the LICENSE file.
           assert.instanceOf(cssRules[i], window.CSSStyleRule);
         }
         runTests(target);
+        assert.equal(Platform.styleResolver.loader.requests, 10, 'Number of stylesheet requests were not expected');
       });
     }
 


### PR DESCRIPTION
The Loader now caches all requests made for that loader, minimizing network requests for styling.

Calls to `process` will return the all content ever fetched, as it was easier than trying to return only the relevant portion of the map.

@sorvell PTAL
