### PR TITLE
load resources with query offered by platform.js

### DIFF
--- a/build/boot.js
+++ b/build/boot.js
@@ -27,6 +27,8 @@ window.logFlags = window.logFlags || {};
       n = a[i];
       if (n.name !== 'src') {
         flags[n.name] = n.value || true;
+      } else if (n.value.indexOf('?') != -1) {
+        scope.version = n.value.substring(n.value.indexOf('?') + 1);
       }
     }
   }

--- a/src/loader.js
+++ b/src/loader.js
@@ -83,12 +83,10 @@
     xhr: function(url) {
       this.requests++;
       var request = new XMLHttpRequest();
-      if (url.indexOf('?') != -1) {
-        // do nothing if query is provided
-      } else if (scope.version) {
-        url += '?' + scope.version;
-      } else if (scope.flags.debug || scope.flags.bust) {
+      if (scope.flags.debug || scope.flags.bust) {
         url += '?' + Math.random();
+      } else if (url.indexOf('?') == -1 && scope.version) {
+        url += '?' + scope.version;
       }
       request.open('GET', url, true);
       request.send();

--- a/src/loader.js
+++ b/src/loader.js
@@ -83,6 +83,13 @@
     xhr: function(url) {
       this.requests++;
       var request = new XMLHttpRequest();
+      if (url.indexOf('?') != -1) {
+        // do nothing if query is provided
+      } else if (scope.version) {
+        url += '?' + scope.version;
+      } else if (scope.flags.debug || scope.flags.bust) {
+        url += '?' + Math.random();
+      }
       request.open('GET', url, true);
       request.send();
       request.onerror = request.onload = this.handleXhr.bind(this, request);


### PR DESCRIPTION
Normally, there would be version number for `platform.js`. And there always be version number in the home page of `http://www.polymer-project.org/`.

This patch and other patch in https://github.com/Polymer/HTMLImports add the version to the query of resources, make it easier for developer to manage the url.

Usage:

```
<script src="/platform.js?2014xxxx"></script>
```

Then, all the link with import, and css will be requested added the version in the platform.js.

And this patch need the change in https://github.com/Polymer/HTMLImports, please refer to https://github.com/Polymer/HTMLImports/pull/70
