### PR TITLE
make the resource in css always be absolute

### DIFF
--- a/src/url.js
+++ b/src/url.js
@@ -37,7 +37,7 @@ var urlResolver = {
   },
   resolveStyle: function(style, url) {
     url = url || style.ownerDocument.baseURI;
-    style.textContent = this.resolveCssText(style.textContent, url);
+    style.textContent = this.resolveCssText(style.textContent, url, true);
   },
   resolveCssText: function(cssText, baseUrl, keepAbsolute) {
     cssText = replaceUrlsInCssText(cssText, baseUrl, keepAbsolute, CSS_URL_REGEXP);


### PR DESCRIPTION
Our platform is built on polymer and pjax. But there is an issue for the import of css.

When the element is resolved in the `/path/a/b`, and use the `url:(urlpath)`, it's resolved to a relative path, like `../../path/a/b/urlpath`. And then, if the page is switch to another path, like `/path/a/c/d/e`, as the page is not refreshed, then the path is the same as `../../path/a/b/urlpath`, so the resource cannot be visited.

Now, we have following solutions:
1. deploy the static element to another host, then makeRelPath won't work, then the absolute link works well
2. in the element, using absolute path, however, there is no recommend..
3. use base64 instead of relative resource.
4. This pull request...
