### PR TITLE
Include URL hash in build.log

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -71,6 +71,7 @@ module.exports = function(grunt) {
             '../HTMLImports',
             '../ShadowDOM',
             '../URL',
+            '../WeakMap',
             '../platform-dev'
           ]
         },

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -70,6 +70,7 @@ module.exports = function(grunt) {
             '../CustomElements',
             '../HTMLImports',
             '../ShadowDOM',
+            '../URL',
             '../platform-dev'
           ]
         },


### PR DESCRIPTION
URL was included in platform.js, but was missing in the build.log file
