### PR TITLE
Make boot-time shadow dom warning a log instead

### DIFF
--- a/build/boot.js
+++ b/build/boot.js
@@ -46,7 +46,7 @@ window.logFlags = window.logFlags || {};
   }
 
   if (flags.shadow && document.querySelectorAll('script').length > 1) {
-    console.log('platform.js is not the first script on the page. ' +
+    console.log('Warning: platform.js is not the first script on the page. ' +
         'See http://www.polymer-project.org/docs/start/platform.html#setup ' +
         'for details.');
   }

--- a/build/boot.js
+++ b/build/boot.js
@@ -46,7 +46,7 @@ window.logFlags = window.logFlags || {};
   }
 
   if (flags.shadow && document.querySelectorAll('script').length > 1) {
-    console.warn('platform.js is not the first script on the page. ' +
+    console.log('platform.js is not the first script on the page. ' +
         'See http://www.polymer-project.org/docs/start/platform.html#setup ' +
         'for details.');
   }


### PR DESCRIPTION
Change console.warn() on boot when platform.js is not first script on page to console.log() - some javascript testing frameworks insert javascript at the start of the html to assist with accurate testing, and will fail tests if they see console.warn().
